### PR TITLE
Class racial mounts (#1)

### DIFF
--- a/src/server/game/AI/NpcBots/bot_ai.cpp
+++ b/src/server/game/AI/NpcBots/bot_ai.cpp
@@ -4932,12 +4932,12 @@ void bot_ai::_updateMountedState()
             uint32 mountSpeed = 0;
             Aura *mountSpeedAura = master->GetAura(mount);
             if (mountSpeedAura->GetEffect(AFLAG_EFF_INDEX_0)->GetAuraType() == SPELL_AURA_MOD_INCREASE_MOUNTED_SPEED)
-                mountSpeed = mountSpeedAura->GetEffect(AFLAG_EFF_INDEX_0)->GetAmount(); 
+                mountSpeed = mountSpeedAura->GetEffect(AFLAG_EFF_INDEX_0)->GetAmount();
             else if (mountSpeedAura->GetEffect(AFLAG_EFF_INDEX_1)->GetAuraType() == SPELL_AURA_MOD_INCREASE_MOUNTED_SPEED)
                 mountSpeed = mountSpeedAura->GetEffect(AFLAG_EFF_INDEX_1)->GetAmount();
             else if (mountSpeedAura->GetEffect(AFLAG_EFF_INDEX_2)->GetAuraType() == SPELL_AURA_MOD_INCREASE_MOUNTED_SPEED)
                 mountSpeed = mountSpeedAura->GetEffect(AFLAG_EFF_INDEX_2)->GetAmount();
-            
+
             //if not flying mount, and not in AQ40, and speed makes sense, get class specific mounts
             if (!master->CanFly() && me->GetMapId() != 531 && (mountSpeed < 130 && mountSpeed > 30))
             {

--- a/src/server/game/AI/NpcBots/bot_ai.cpp
+++ b/src/server/game/AI/NpcBots/bot_ai.cpp
@@ -4914,7 +4914,7 @@ void bot_ai::_updateMountedState()
     if (master->IsMounted() && !me->IsMounted() && !master->IsInCombat() && !me->IsInCombat() && !me->GetVictim())
     {
         uint32 mount = 0;
-        Unit::AuraEffectList const &mounts = master->GetAuraEffectsByType(SPELL_AURA_MOUNTED);
+        Unit::AuraEffectList const &mounts = master->GetAuraEffectsByType(SPELL_AURA_MOD_INCREASE_MOUNTED_SPEED);
         if (!mounts.empty())
         {
             //Winter Veil addition
@@ -4927,7 +4927,43 @@ void bot_ai::_updateMountedState()
         {
             if (me->HasAuraType(SPELL_AURA_MOUNTED))
                 me->RemoveAurasByType(SPELL_AURA_MOUNTED);
+            //if not flying mount and not in AQ40, get class specific mounts
+            uint32 mountSpeed = mounts.front()->GetAmount();
 
+            if (!master->CanFly() && me->GetMapId() != 531 && (mountSpeed < 130 && mountSpeed > 30))
+            {
+
+                switch (me->GetBotClass())
+                {
+                    case BOT_CLASS_DARK_RANGER:
+                        mount = BOT_DARK_RANGER_MOUNT;
+                        break;
+                    case BOT_CLASS_WARLOCK:
+                        if (mountSpeed<80) { mount = BOT_WARLOCK_MOUNT; }
+                        else { mount = BOT_WARLOCK_FAST_MOUNT; }
+                        break;
+                    case BOT_CLASS_PALADIN:
+                        if (me->GetRace()==RACE_BLOODELF)
+                        {
+                            if (mountSpeed<80) { mount = BOT_BE_PALLY_MOUNT; }
+                            else { mount = BOT_BE_PALLY_FAST_MOUNT; }
+                        }
+                        else
+                        {
+                            if (mountSpeed<80) { mount = BOT_ALLI_PALLY_MOUNT; }
+                            else { mount = BOT_ALLI_PALLY_FAST_MOUNT; }
+                        }
+                        break;
+                    case BOT_CLASS_DEATH_KNIGHT:
+                        mount = BOT_DEATH_KNIGHT_MOUNT;
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+ 
+                    
             //me->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_NOT_MOUNTED);
 
             //if (!GetSpell(mount))

--- a/src/server/game/AI/NpcBots/botcommon.h
+++ b/src/server/game/AI/NpcBots/botcommon.h
@@ -1044,4 +1044,15 @@ enum BotVehicleStrats
     BOT_VEH_STRAT_GENERIC
 };
 
+enum BotMounts
+{
+    BOT_DARK_RANGER_MOUNT           = 17481, // Deathcharger's Reins
+    BOT_BE_PALLY_FAST_MOUNT         = 34767,
+    BOT_BE_PALLY_MOUNT              = 34769,
+    BOT_ALLI_PALLY_FAST_MOUNT       = 23214,
+    BOT_ALLI_PALLY_MOUNT            = 13819,
+    BOT_DEATH_KNIGHT_MOUNT          = 48778,
+    BOT_WARLOCK_FAST_MOUNT          = 23161,
+    BOT_WARLOCK_MOUNT               = 5784
+};
 #endif


### PR DESCRIPTION
I have updated the bots mod to have the class specific mounts for warlocks/paladins/death knights. 
I think I have enough sanity checks where it reverts to the current behavior.

* Updates bot_ai.cpp
* Updates botcommon.h

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)
Builds
works in game, properly selects between slow/fast mount.
In Outland, when summoning a flying mount as player, bots correctly revert to old behavior and use the same flying mount

**Known issues and TODO list**:
TODO: racial mounts for everyone else
- [ ] 
- [ ] 
